### PR TITLE
Added argument for start time

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ OPTIONS
 	-t, --task [taskId]
 	Set the taskId to log to (see --tasks)
 
-    -T --start-time [hh:mm]
-    Set the start time to log (default "09:00")
+	-T --start-time [hh:mm]
+	Set the start time to log (default "09:00")
 
 EXAMPLES
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ OPTIONS
 	-t, --task [taskId]
 	Set the taskId to log to (see --tasks)
 
+    -T --start-time [hh:mm]
+    Set the start time to log (default "09:00")
+
 EXAMPLES
 
-    nodejs hours.js --entry --task 6905921 --hours 1 --minutes 30 
+    nodejs hours.js --entry --task 6905921 --start-time "09:00" --hours 1 --minutes 30 
                     --billable 0 --description "Friday Standup"
     Logs an hour and a half for a long Friday standup
 
-    nodejs hours.js -e -t 6905921 -H 1 -M 30 -b 0 -m "Friday Standup"
+    nodejs hours.js -e -t 6905921 -T "09:00" -H 1 -M 30 -b 0 -m "Friday Standup"
     Same as above but using letters instead
         
 

--- a/hours.js
+++ b/hours.js
@@ -45,6 +45,7 @@ const parseProgramArguments = (args) => {
     argList['date'] = getArgEntry('d','[yyyymmdd]','Set date to log for (default today)', dateFormat(new Date(), "yyyymmdd"));
     argList['description'] = getArgEntry('m','[message]','Set description to log (default empty)', '');
     argList['task'] = getArgEntry('t','[taskId]','Set the taskId to log to (see --tasks)', '');
+    argList['start-time'] = getArgEntry('T', '[hh:mm]', 'Set the start time to log (default 09:00)', '09:00');
 
     if (args !== undefined) {
         Object.keys(argList).forEach( key => {
@@ -92,10 +93,10 @@ const printUsage = () => {
 
     console.log('\nEXAMPLES');
     console.log(`
-    nodejs hours.js --entry --task 6905921 --hours 1 --minutes 30 --billable 0 --description "Friday Standup"
+    nodejs hours.js --entry --task 6905921 --start-time "09:00" --hours 1 --minutes 30 --billable 0 --description "Friday Standup"
     Logs an hour and a half for a long Friday standup
 
-    nodejs hours.js -e -t 6905921 -H 1 -M 30 -b 0 -m "Friday Standup"
+    nodejs hours.js -e -t 6905921 -T "09:00" -H 1 -M 30 -b 0 -m "Friday Standup"
     Same as above but using letters instead
         `
     );
@@ -133,6 +134,7 @@ else {
                 hours: argList['hours'].value,
                 minutes: argList['minutes'].value,
                 isbillable: argList['billable'].value,
+                time: argList['start-time'].value
             });
             console.log(resp);
         }

--- a/teamwork.js
+++ b/teamwork.js
@@ -189,6 +189,7 @@ const prettyJson = (json) => {
  * @param entry.hours Number of hours to log
  * @param entry.minutes Number of minutes to log
  * @param entry.isbillable 1 if time is billable
+ * @param entry.time The start time of the entry
  */
 const sendTimeEntry = (entry) => {
 
@@ -203,7 +204,7 @@ const sendTimeEntry = (entry) => {
             minutes: entry.minutes, 
             isbillable: entry.isbillable,
             'person-id': me.person.id,
-            time: '9:00',
+            time: entry.time,
             'tags': ''
         }
     };


### PR DESCRIPTION
I added a new argument to specify the start time when creating a new time entry. To use the new argument, specify either `--start-time` or `-T`. I also updated the README's examples to use the new argument.