### PR TITLE
Fix initial setup errors

### DIFF
--- a/interactive-mode.js
+++ b/interactive-mode.js
@@ -25,7 +25,7 @@ const prettyJson = (json) => {
 
 const state = {
     data: {
-        projects: teamwork.getProjects(),
+        projects: userData.get().key ? teamwork.getProjects() : undefined,
         tasklists: undefined,
         tasks: undefined,
         timeEntries: undefined

--- a/user-data.js
+++ b/user-data.js
@@ -39,7 +39,8 @@ const get = () => {
     } catch (e) {
         console.log(e);
     }
-    return { teamwork: {}};
+    
+    return data = { teamwork: {}};
 }
 
 const save = () => {


### PR DESCRIPTION
Was getting this on setup attempts:
```
~/dev/rts/teamwork-cli   fix-setup-errors  node hours.js --url https://rtslabs.teamwork.com
{ YAMLException: unacceptable kind of an object to dump [object Undefined]
    at writeNode (/Users/taylorcampbell/dev/rts/teamwork-cli/node_modules/js-yaml/lib/js-yaml/dumper.js:748:13)
    at dump (/Users/taylorcampbell/dev/rts/teamwork-cli/node_modules/js-yaml/lib/js-yaml/dumper.js:809:7)
    at Object.safeDump (/Users/taylorcampbell/dev/rts/teamwork-cli/node_modules/js-yaml/lib/js-yaml/dumper.js:815:10)
    at Object.save (/Users/taylorcampbell/dev/rts/teamwork-cli/user-data.js:47:26)
    at persistUrl (/Users/taylorcampbell/dev/rts/teamwork-cli/hours.js:129:18)
    at Object.<anonymous> (/Users/taylorcampbell/dev/rts/teamwork-cli/hours.js:174:13)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
  name: 'YAMLException',
  reason: 'unacceptable kind of an object to dump [object Undefined]',
  mark: undefined,
  message: 'unacceptable kind of an object to dump [object Undefined]' }
{ YAMLException: unacceptable kind of an object to dump [object Undefined]
    at writeNode (/Users/taylorcampbell/dev/rts/teamwork-cli/node_modules/js-yaml/lib/js-yaml/dumper.js:748:13)
    at dump (/Users/taylorcampbell/dev/rts/teamwork-cli/node_modules/js-yaml/lib/js-yaml/dumper.js:809:7)
    at Object.safeDump (/Users/taylorcampbell/dev/rts/teamwork-cli/node_modules/js-yaml/lib/js-yaml/dumper.js:815:10)
    at Object.save (/Users/taylorcampbell/dev/rts/teamwork-cli/user-data.js:47:26)
    at Object.<anonymous> (/Users/taylorcampbell/dev/rts/teamwork-cli/hours.js:239:10)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
  name: 'YAMLException',
  reason: 'unacceptable kind of an object to dump [object Undefined]',
  mark: undefined,
  message: 'unacceptable kind of an object to dump [object Undefined]' }
```

I had to do two things to fix:
1. `userData.get()` was just returning a new object, not initializing the `data` object.
   - Specifically, this would then cause `persistKey` to not work: `userData.get().teamwork.key = key;`
2. When required, `interactive-mode.js` was calling `teamwork.getProjects()` immediately. This was breaking when the userData wasn't yet saved (like, when trying to set key or url :))

Feel free to close and fix in a more elegant way ;).